### PR TITLE
pre-flight closure checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ What `deploy-flake` does that I think are advantages over `deploy-rs`:
 
 * Better system activation story: The flake configuration is first applied via `nixos-rebuild test`, and only if that works, added to the boot entries via the equivalent of `nixos-rebuild boot`.
 
+* Optional system closure self-check script: If you use `system.extraSystemBuilderCmds` to write a self-test program into your system closure, `deploy-flake` can optionally invoke it via the `--pre-activate-script=relative-pathname` option and will not kick off a deploy on the machine if that program returns a non-0 status code.
+
 * Nicer story around running the test process in the background: It uses `systemd-run` to spawn the activation as a systemd unit, which will allow the control process to get disconnected at any point in time & the deployment can continue.
 
 * Parallelism: You can deploy one flake to multiple hosts in one invocation, in parallel.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ impl SystemConfiguration {
 
     #[instrument(level="DEBUG", skip(self) err)]
     pub async fn preflight_check(&self) -> Result<(), anyhow::Error> {
-        self.system.preflight_check().await
+        self.system.preflight_check_system().await
     }
 
     /// Returns the system that the configuration resides on.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,9 @@ impl SystemConfiguration {
 
     #[instrument(level="DEBUG", skip(self) err)]
     pub async fn preflight_check_closure(&self, script: &Path) -> Result<(), anyhow::Error> {
-        self.system.preflight_check_closure(&self.path, script).await
+        self.system
+            .preflight_check_closure(&self.path, script)
+            .await
     }
 
     /// Returns the system that the configuration resides on.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,8 +158,13 @@ impl SystemConfiguration {
     }
 
     #[instrument(level="DEBUG", skip(self) err)]
-    pub async fn preflight_check(&self) -> Result<(), anyhow::Error> {
+    pub async fn preflight_check_system(&self) -> Result<(), anyhow::Error> {
         self.system.preflight_check_system().await
+    }
+
+    #[instrument(level="DEBUG", skip(self) err)]
+    pub async fn preflight_check_closure(&self, script: &Path) -> Result<(), anyhow::Error> {
+        self.system.preflight_check_closure(&self.path, script).await
     }
 
     /// Returns the system that the configuration resides on.

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ struct Opts {
     /// system being deployed, that checks whether the system closure
     /// is deployable. This program should be created with
     /// `system.extraSystemBuilderCmds` for NixOS.
-    #[clap(long, require_equals=true, value_name = "PROGRAM")]
+    #[clap(long, require_equals = true, value_name = "PROGRAM")]
     pre_activate_script: Option<PathBuf>,
 
     /// Whether to run the "test" step, updating the system config
@@ -166,7 +166,15 @@ async fn main() -> Result<(), anyhow::Error> {
         let build_cmdline = build_cmdline.clone();
         let pre_activate_script = pre_activate_script.clone();
         task::spawn(async move {
-            deploy(flake, destination, do_preflight, pre_activate_script, do_test, build_cmdline).await
+            deploy(
+                flake,
+                destination,
+                do_preflight,
+                pre_activate_script,
+                do_test,
+                build_cmdline,
+            )
+            .await
         })
     }))
     .await?;

--- a/src/os.rs
+++ b/src/os.rs
@@ -19,6 +19,9 @@ pub trait NixOperatingSystem: fmt::Debug {
     /// Checks if the target system is able to be deployed to.
     async fn preflight_check_system(&self) -> Result<(), anyhow::Error>;
 
+    /// Checks if the built closure can be deployed to the system.
+    async fn preflight_check_closure(&self, derivation: &Path, script: &Path) -> Result<(), anyhow::Error>;
+
     /// Builds a system configuration closure from the flake and
     /// returns the path to the built closure and the name of the
     /// system that it was built for.

--- a/src/os.rs
+++ b/src/os.rs
@@ -20,7 +20,11 @@ pub trait NixOperatingSystem: fmt::Debug {
     async fn preflight_check_system(&self) -> Result<(), anyhow::Error>;
 
     /// Checks if the built closure can be deployed to the system.
-    async fn preflight_check_closure(&self, derivation: &Path, script: &Path) -> Result<(), anyhow::Error>;
+    async fn preflight_check_closure(
+        &self,
+        derivation: &Path,
+        script: &Path,
+    ) -> Result<(), anyhow::Error>;
 
     /// Builds a system configuration closure from the flake and
     /// returns the path to the built closure and the name of the

--- a/src/os.rs
+++ b/src/os.rs
@@ -16,8 +16,8 @@ pub enum Verb {
 
 #[async_trait::async_trait]
 pub trait NixOperatingSystem: fmt::Debug {
-    /// Checks if the system is able to be deployed to.
-    async fn preflight_check(&self) -> Result<(), anyhow::Error>;
+    /// Checks if the target system is able to be deployed to.
+    async fn preflight_check_system(&self) -> Result<(), anyhow::Error>;
 
     /// Builds a system configuration closure from the flake and
     /// returns the path to the built closure and the name of the

--- a/src/os/nixos.rs
+++ b/src/os/nixos.rs
@@ -137,14 +137,18 @@ impl NixOperatingSystem for Nixos {
     }
 
     #[instrument(level = "INFO", err)]
-    async fn preflight_check_closure(&self, derivation: &Path, script: &Path) -> Result<(), anyhow::Error> {
+    async fn preflight_check_closure(
+        &self,
+        derivation: &Path,
+        script: &Path,
+    ) -> Result<(), anyhow::Error> {
         let script_path = derivation.join(script);
 
         let mut cmd = self.session.command("sudo");
         cmd.arg(script_path.to_string_lossy());
         self.run_command(cmd)
             .await
-            .with_context(|| format!("System closure self-checks failed"))?;
+            .context("System closure self-checks failed")?;
         Ok(())
     }
 

--- a/src/os/nixos.rs
+++ b/src/os/nixos.rs
@@ -112,7 +112,7 @@ impl NixOperatingSystem for Nixos {
         cmd.args(["systemctl", "is-system-running", "--wait"]);
         let health = cmd.output().await?;
         let health_data = String::from_utf8_lossy(&health.stdout);
-        let status = health_data.strip_suffix('\n');
+        let status = health_data.strip_suffix('\n').unwrap_or("");
         if !health.status.success() {
             log::error!(
                 ?status,
@@ -133,6 +133,18 @@ impl NixOperatingSystem for Nixos {
             anyhow::bail!("Can not deploy to an unhealthy system");
         }
         log::event!(log::Level::DEBUG, ?status, "System is healthy");
+        Ok(())
+    }
+
+    #[instrument(level = "INFO", err)]
+    async fn preflight_check_closure(&self, derivation: &Path, script: &Path) -> Result<(), anyhow::Error> {
+        let script_path = derivation.join(script);
+
+        let mut cmd = self.session.command("sudo");
+        cmd.arg(script_path.to_string_lossy());
+        self.run_command(cmd)
+            .await
+            .with_context(|| format!("System closure self-checks failed"))?;
         Ok(())
     }
 

--- a/src/os/nixos.rs
+++ b/src/os/nixos.rs
@@ -106,7 +106,7 @@ impl Nixos {
 #[async_trait::async_trait]
 impl NixOperatingSystem for Nixos {
     #[instrument(level = "INFO", err)]
-    async fn preflight_check(&self) -> Result<(), anyhow::Error> {
+    async fn preflight_check_system(&self) -> Result<(), anyhow::Error> {
         let mut cmd = self.session.command("sudo");
         cmd.stdout(Stdio::piped());
         cmd.args(["systemctl", "is-system-running", "--wait"]);


### PR DESCRIPTION
The new option `--pre-activate-system` allows a system closure to define self-checks against the concrete deploy environment that must succeed before a real deploy is kicked off. These checks can test whether all the zfs datasets that are expected by backup processes are in place, whether all the drivers that are required do end up in the final system closure, or other host environment/expected-system mismatches.
