### PR TITLE
Get rid of dynamic dispatch, async-trait; nixos-only right now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,17 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
-name = "async-trait"
-version = "0.1.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,7 +140,6 @@ name = "deploy-flake"
 version = "0.0.1-dev"
 dependencies = [
  "anyhow",
- "async-trait",
  "clap",
  "futures",
  "openssh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.79"
-async-trait = "0.1.77"
 futures = "*"
 openssh = "0.10.3"
 serde_json = "1.0.113"

--- a/src/os.rs
+++ b/src/os.rs
@@ -14,8 +14,7 @@ pub enum Verb {
     Boot,
 }
 
-#[async_trait::async_trait]
-pub trait NixOperatingSystem: fmt::Debug {
+pub(crate) trait NixOperatingSystem: fmt::Debug {
     /// Checks if the target system is able to be deployed to.
     async fn preflight_check_system(&self) -> Result<(), anyhow::Error>;
 


### PR DESCRIPTION
Since we're not supporting any non-nixos traits rn (and async-trait causes spurious cargo-clippy errors at the moment via https://rust-lang.github.io/rust-clippy/master/index.html#/blocks_in_conditions) AND stable rust now supports async functions in non-pub traits, I've decided to rework the flavor & NixOperatingSystem traits to not use the async-trait macro anymore.

This means:
* Hardcode that all the system configs are on Nixos, get rid of dyn dispatch.

* Mark the pub traits as pub(crate) instead. I think there's no outside users right now, and that quiets rust warnings.

* Use the Verb::Build variant, which rust now started to complain about. Welp.