### PR TITLE
Infer the preflight activation script from preroll-safety's default

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ What `deploy-flake` does that I think are advantages over `deploy-rs`:
 
 * Better system activation story: The flake configuration is first applied via `nixos-rebuild test`, and only if that works, added to the boot entries via the equivalent of `nixos-rebuild boot`.
 
-* Optional system closure self-check script: If you use `system.extraSystemBuilderCmds` to write a self-test program into your system closure, `deploy-flake` can optionally invoke it via the `--pre-activate-script=relative-pathname` option and will not kick off a deploy on the machine if that program returns a non-0 status code.
+* Optional system closure self-check script: If you use `system.extraSystemBuilderCmds` to write a self-test program into your system closure, `deploy-flake` can optionally invoke it via the `--pre-activate-script=relative-pathname` option and will not kick off a deploy on the machine if that program returns a non-0 status code. If your system configuration uses [preroll-safety](https://github.com/boinkor-net/preroll-safety), the script it emits by default is detected and used for this self-check automatically.
 
 * Nicer story around running the test process in the background: It uses `systemd-run` to spawn the activation as a systemd unit, which will allow the control process to get disconnected at any point in time & the deployment can continue.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,10 @@ impl SystemConfiguration {
     }
 
     #[instrument(level="DEBUG", skip(self) err)]
-    pub async fn preflight_check_closure(&self, script: &Path) -> Result<(), anyhow::Error> {
+    pub async fn preflight_check_closure(
+        &self,
+        script: Option<&Path>,
+    ) -> Result<(), anyhow::Error> {
         self.system
             .preflight_check_closure(&self.path, script)
             .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,8 +96,10 @@ struct Opts {
 
     /// A program contained in the new system closure, run on the
     /// system being deployed, that checks whether the system closure
-    /// is deployable. This program should be created with
-    /// `system.extraSystemBuilderCmds` for NixOS.
+    /// is deployable. This program can be created with
+    /// `system.extraSystemBuilderCmds` for NixOS.  See the
+    /// https://github.com/boinkor-net/preroll-safety library for an
+    /// example of pre-activation safety checks.
     #[clap(long, require_equals = true, value_name = "PROGRAM")]
     pre_activate_script: Option<PathBuf>,
 
@@ -213,10 +215,9 @@ async fn deploy(
         log::event!(log::Level::DEBUG, dest=?destination.hostname, "Skipping system health check");
     }
 
-    if let Some(script) = pre_activate_script {
-        log::event!(log::Level::INFO, dest=?destination.hostname, script=?script, "Running pre-activation script");
-        built.preflight_check_closure(&script).await?;
-    }
+    built
+        .preflight_check_closure(pre_activate_script.as_deref())
+        .await?;
 
     if do_test == Behavior::Run {
         log::event!(log::Level::DEBUG, configuration=?built.configuration(), system_name=?built.for_system(), "Testing");

--- a/src/os.rs
+++ b/src/os.rs
@@ -22,7 +22,7 @@ pub(crate) trait NixOperatingSystem: fmt::Debug {
     async fn preflight_check_closure(
         &self,
         derivation: &Path,
-        script: &Path,
+        script: Option<&Path>,
     ) -> Result<(), anyhow::Error>;
 
     /// Builds a system configuration closure from the flake and


### PR DESCRIPTION
Now, if you don't pass --pre-activate-script, deploy-flake checks if the script emitted by preroll-safety exists in the closure & runs it as the preflight closure check.